### PR TITLE
Remove overall indentation in snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ The line numbers specified in `data-sample-mark` are relative to the snippet
 itself, not to the file from which the snippet was extracted. Also, line
 ranges are supported, just like for extracting snippets from a file.
 
+### Remove indentation
+If all lines of the sample have an overall indentation you can remove it using the 
+attribute `data-sample-indent`.
+
+```html
+<pre><code data-sample='path/to/source#sample-name' data-sample-indent="remove"></code></pre>
+<pre><code data-sample='path/to/source#sample-name' data-sample-indent="keep"></code></pre>
+```
+
+You can change the default behaviour (snippets without the attribute) using
+an the option `sampler.removeIndentation`.
+
+```js
+{ 
+    sampler : {
+        removeIndentation: true
+    } 
+}
+```
+
+
+
+
 ### Example
 
 It's that simple! To get started, you can find an example of using the plugin

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ attribute `data-sample-indent`.
 ```
 
 You can change the default behaviour (snippets without the attribute) using
-an the option `sampler.removeIndentation`.
+an the option `sampler.removeIndentation`. The default value is `false`.
 
 ```js
 { 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ attribute `data-sample-indent`.
 ```
 
 You can change the default behaviour (snippets without the attribute) using
-an the option `sampler.removeIndentation`. The default value is `false`.
+the option `sampler.removeIndentation`. The default value is `false`.
 
 ```js
 { 

--- a/example/index.html
+++ b/example/index.html
@@ -94,6 +94,11 @@
                     <h2>Skip some lines in the file, with line selection</h2>
                     <pre><code data-sample='skip-sample.cpp#3-9'></code></pre>
                 </section>
+
+                <section>
+                    <h2>Remove indent</h2>
+                    <pre><code data-sample='sample.c#6' data-sample-indent="remove"></code></pre>
+                </section>
             </div>
         </div>
 


### PR DESCRIPTION
This looks for the shortest indentation in the snippet and removes it from all lines. It "undents" the snippet. I added a global option to activate the behavior and an attribute individual configuration.