### PR TITLE
Allow to configure a proxy to fetch the snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,20 @@ the option `sampler.removeIndentation`. The default value is `false`.
 }
 ```
 
+### Fetcher URL
+Defining the fetcher URL will prefix all snippet requests with it. 
 
+```js
+{ 
+    sampler : {
+        fetcherURL: 'task.php?file='
+    } 
+}
+```
 
+If you're trying to load a language that your webserver understands (for example PHP) you
+can create a proxy script that passes the source of the file trough. Be careful to 
+limit the script to the source files you would like to deliver.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,14 @@ the option `sampler.removeIndentation`. The default value is `false`.
 }
 ```
 
-### Fetcher URL
-Defining the fetcher URL will prefix all snippet requests with it. 
+### Proxy URL
+Defining the proxy URL will prefix all snippet requests with it. This allows you to use a script to access the
+snippet files.
 
 ```js
 { 
     sampler : {
-        fetcherURL: 'task.php?file='
+        proxyURL: 'task.php?file='
     } 
 }
 ```

--- a/sampler.js
+++ b/sampler.js
@@ -165,14 +165,14 @@
     var config = Reveal.getConfig() || {};
     config.sampler = config.sampler || {};
     var options = {
-        fetcherURL: config.sampler.fetcherURL || '',
+        proxyURL: config.sampler.proxyURL || '',
         removeIndentation: !!config.sampler.removeIndentation
     };
 
     var elements = document.querySelectorAll('[data-sample]');
     elements.forEach(function(element) {
         var slug = element.getAttribute('data-sample').match(/([^#]+)(?:#(.+))?/);
-        var file = options.fetcherURL + slug[1];
+        var file = options.proxyURL + slug[1];
         var selector = slug[2];
         var extractor = getSnippetExtractor(selector);
 

--- a/sampler.js
+++ b/sampler.js
@@ -165,13 +165,14 @@
     var config = Reveal.getConfig() || {};
     config.sampler = config.sampler || {};
     var options = {
+        fetcherURL: config.sampler.fetcherURL || '',
         removeIndentation: !!config.sampler.removeIndentation
     };
 
     var elements = document.querySelectorAll('[data-sample]');
     elements.forEach(function(element) {
         var slug = element.getAttribute('data-sample').match(/([^#]+)(?:#(.+))?/);
-        var file = slug[1];
+        var file = options.fetcherURL + slug[1];
         var selector = slug[2];
         var extractor = getSnippetExtractor(selector);
 


### PR DESCRIPTION
I am using sampler with PHP snippets, but my webserver (local inside the IDE) support PHP. So I only get empty responses. :-) 

A small proxy script allows to fetch the source of the PHP files.

This branch includes the changes for the indentation behavior. Both read options, so they might conflict otherwise.