### PR TITLE
WIP: Refactor to simple parser approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,20 @@ the option `sampler.removeIndentation`. The default value is `false`.
 }
 ```
 
+### Fetcher URL
+Defining the fetcher URL will prefix all snippet requests with it. 
 
+```js
+{ 
+    sampler : {
+        fetcherURL: 'task.php?file='
+    } 
+}
+```
 
+If you're trying to load a language that your webserver understands (for example PHP) you
+can create a proxy script that passes the source of the file trough. Be careful to 
+limit the script to the source files you would like to deliver.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,22 @@ class Foo {
 // end-sample
 ```
 
+Lines containing a comment `mark-sample` will be marked and the comment will be removed.
+The plugin recognizes the following strings as mark comments:
+ 
+ * `// mark-sample`
+ * `# mark-sample`
+ * `/* mark-sample */`
+ * `<!-- mark-sample -->` 
+
+```c++
+// sample(foo)
+class Foo {
+    void hello() { std::cout << "hello!" << std::endl; } // mark-sample
+};
+// end-sample
+```
+
 ### Marking lines in a sample
 Specific lines or line ranges can be marked in a sample. To do this, use the
 `data-sample-mark` attribute as follows:
@@ -103,6 +119,27 @@ Specific lines or line ranges can be marked in a sample. To do this, use the
 The line numbers specified in `data-sample-mark` are relative to the snippet
 itself, not to the file from which the snippet was extracted. Also, line
 ranges are supported, just like for extracting snippets from a file.
+
+### Line numbers
+You can let the plugin add line numbers to the sample. `true` adds line numbers starting with 1, a number
+adds line number starting with it and `original` copies the line numbers from the source file.
+
+```html
+<pre><code data-sample='path/to/source#sample-name' data-sample-line-numbers="true"></code></pre>
+<pre><code data-sample='path/to/source#sample-name' data-sample-line-numbers="42"></code></pre>
+<pre><code data-sample='path/to/source#sample-name' data-sample-line-numbers="original"></code></pre>
+```
+
+The global option `sampler.lineNumbers` allows for `true`, `false` and `'original'` it controls the
+line numbers on code blocks without the `data-sample-line-numbers`. The default value is `false` (no line numbers).
+
+```js
+{ 
+    sampler : {
+        lineNumbers: true
+    } 
+}
+```
 
 ### Remove indentation
 If all lines of the sample have an overall indentation you can remove it using the 
@@ -123,6 +160,37 @@ the option `sampler.removeIndentation`. The default value is `false`.
     } 
 }
 ```
+
+### Skip lines 
+To skip lines add a the attribute `data-sample-skip`. 
+
+```html
+<pre><code data-sample='path/to/source' data-sample-skip="delimiter"></code></pre>
+<pre><code data-sample='path/to/source' data-sample-skip="1-3,4"></code></pre>
+<pre><code data-sample='path/to/source' data-sample-skip="delimiter,12"></code></pre>
+```
+
+#### Skip: delimiter, delimiters
+
+`delimiter` or `delimiters` will skip lines that mark the start/end of a sample. Add this to the option to skip these 
+lines for whole file or line number samples. This will not affect named samples (they never include that lines).
+
+You can set this globally using the option `sampler.skip`.
+
+```js
+{ 
+    sampler : {
+        skip: ['delimiter']
+    } 
+}
+```
+
+#### Skip: line ranges
+
+The line numbers and ranges specified in `data-sample-skip` are relative to the snippet
+itself, not to the file from which the snippet was extracted.
+
+Delimiter lines will count if included, only. 
 
 ### Proxy URL
 Defining the proxy URL will prefix all snippet requests with it. This allows you to use a script to access the

--- a/README.md
+++ b/README.md
@@ -124,13 +124,14 @@ the option `sampler.removeIndentation`. The default value is `false`.
 }
 ```
 
-### Fetcher URL
-Defining the fetcher URL will prefix all snippet requests with it. 
+### Proxy URL
+Defining the proxy URL will prefix all snippet requests with it. This allows you to use a script to access the
+snippet files.
 
 ```js
 { 
     sampler : {
-        fetcherURL: 'task.php?file='
+        proxyURL: 'task.php?file='
     } 
 }
 ```

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
     "name": "reveal-sampler",
-    "version": "1.0.0",
     "description": "A reveal.js plugin to include code samples in slides",
     "homepage": "https://github.com/ldionne/reveal-sampler",
     "license": "MIT",
@@ -9,7 +8,7 @@
     ],
     "keywords": [
         "reveal-js",
-        "revieal-plugin",
+        "reveal-plugin",
         "slide",
         "sampler"
     ],
@@ -18,6 +17,7 @@
     ],
     "ignore": [
         "**/.*",
+        "docs/",
         "example/"
     ]
 }

--- a/example/index.html
+++ b/example/index.html
@@ -47,6 +47,11 @@
                 </section>
 
                 <section>
+                    <h2>XML markup</h2>
+                    <pre><code data-sample='sample.xml#address' data-sample-indent="remove"></code></pre>
+                </section>
+
+                <section>
                     <h2>Many samples in the same file</h2>
                     <pre><code data-sample='many-samples.cpp#sample-1'></code></pre>
                     <pre><code data-sample='many-samples.cpp#sample-2'></code></pre>

--- a/example/index.html
+++ b/example/index.html
@@ -25,9 +25,6 @@
             code mark {
                 background-color: #7B7B7B;
             }
-            code [data-line-number]:before {
-                content: attr(data-line-number) ': ';
-            }
         </style>
     </head>
 
@@ -77,7 +74,7 @@
 
                 <section>
                     <h2>When no sample-name is specified, the whole file is included</h2>
-                    <pre><code data-sample='whole_file.cpp'></code></pre>
+                    <pre><code data-sample='whole_file.cpp' data-sample-skip="delimiter"></code></pre>
                 </section>
 
                 <section>
@@ -88,6 +85,11 @@
                 <section>
                     <h2>Lines 12,13,14</h2>
                     <pre><code data-sample='whole_file.cpp#12,13,14'></code></pre>
+                </section>
+
+                <section>
+                    <h2>Mark some lines in the file</h2>
+                    <pre><code data-sample='mark-sample.cpp#main'></code></pre>
                 </section>
 
                 <section>
@@ -106,6 +108,14 @@
                 </section>
 
                 <section>
+                    <h2>Skip line by index</h2>
+                    <h4>fetch 7-9</h4>
+                    <pre><code data-sample='whole_file.cpp#7-9'></code></pre>
+                    <h4>fetch 7-9, skip sample line 2</h4>
+                    <pre><code data-sample='whole_file.cpp#7-9' data-sample-skip="2"></code></pre>
+                </section>
+
+                <section>
                     <h2>Remove indent</h2>
                     <pre><code data-sample='sample.c#6' data-sample-indent="remove"></code></pre>
                 </section>
@@ -117,7 +127,7 @@
 
                 <section>
                     <h2>Line numbers with offset</h2>
-                    <pre><code data-sample='whole_file.cpp#5-9' data-sample-line-numbers="42"></code></pre>
+                    <pre><code data-sample='whole_file.cpp#5-9' data-sample-line-numbers="8"></code></pre>
                 </section>
 
                 <section>

--- a/example/index.html
+++ b/example/index.html
@@ -56,6 +56,12 @@
                 </section>
 
                 <section>
+                    <h2>Overlapping samples</h2>
+                    <pre><code data-sample='overlapping-samples.cpp#first'></code></pre>
+                    <pre><code data-sample='overlapping-samples.cpp#second'></code></pre>
+                </section>
+
+                <section>
                     <h2>Samples with the same tag in a file are concatenated</h2>
                     <pre><code data-sample='concatenate.cpp#main'></code></pre>
                 </section>
@@ -78,6 +84,7 @@
                     <h2>Lines 5 to 9</h2>
                     <pre><code data-sample='whole_file.cpp#5-9'></code></pre>
                 </section>
+
                 <section>
                     <h2>Lines 12,13,14</h2>
                     <pre><code data-sample='whole_file.cpp#12,13,14'></code></pre>
@@ -101,6 +108,21 @@
                 <section>
                     <h2>Remove indent</h2>
                     <pre><code data-sample='sample.c#6' data-sample-indent="remove"></code></pre>
+                </section>
+
+                <section>
+                    <h2>Line numbers</h2>
+                    <pre><code data-sample='whole_file.cpp#5-9' data-sample-line-numbers="true"></code></pre>
+                </section>
+
+                <section>
+                    <h2>Line numbers with offset</h2>
+                    <pre><code data-sample='whole_file.cpp#5-9' data-sample-line-numbers="42"></code></pre>
+                </section>
+
+                <section>
+                    <h2>Line numbers from file</h2>
+                    <pre><code data-sample='whole_file.cpp#5-9' data-sample-line-numbers="original"></code></pre>
                 </section>
             </div>
         </div>

--- a/example/index.html
+++ b/example/index.html
@@ -25,6 +25,9 @@
             code mark {
                 background-color: #7B7B7B;
             }
+            code [data-line-number]:before {
+                content: attr(data-line-number) ': ';
+            }
         </style>
     </head>
 

--- a/example/mark-sample.cpp
+++ b/example/mark-sample.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+// sample(main)
+int main() {
+    this line should be marked // mark-sample
+    unmarked line
+    this line should be marked too /* mark-sample */
+}
+// end-sample

--- a/example/overlapping-samples.cpp
+++ b/example/overlapping-samples.cpp
@@ -1,0 +1,16 @@
+// The whole file should be included, even if
+// there's something that could match a sample
+
+// sample(first)
+#include <iostream>
+
+// sample(second)
+void hello() {
+    std::cout << "Hello world!" << std::endl;
+}
+// end-sample(first)
+
+int main() {
+
+}
+// end-sample(second)

--- a/example/sample.xml
+++ b/example/sample.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<contact>
+    <firstName>John</firstName>
+    <lastName>Smith</lastName>
+    <age>25</age>
+    <!-- sample(address) -->
+    <address>
+        <streetAddress>21 2nd Street</streetAddress> <!-- mark-sample -->
+        <city>New York</city>
+        <state>NY</state> <!-- skip-sample -->
+        <postalCode>10021</postalCode>
+    </address>
+    <!-- end-sample -->
+    <phoneNumbers>
+        <phoneNumber>
+            <type>home</type>
+            <number>212 555-1234</number>
+        </phoneNumber>
+        <phoneNumber>
+            <type>fax</type>
+            <number>646 555-4567</number>
+        </phoneNumber>
+    </phoneNumbers>
+</contact>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "reveal-sampler",
+    "description": "Embed code samples from files into reveal.js presentations",
+    "main": "sampler.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "docs": "jsdoc -d docs/ sampler.js README.md"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/ldionne/reveal-sampler.git"
+    },
+    "keywords": [
+        "reveal-js",
+        "reveal-plugin",
+        "slide",
+        "slide",
+        "sampler"
+    ],
+    "author": "",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/ldionne/reveal-sampler/issues"
+    },
+    "homepage": "https://github.com/ldionne/reveal-sampler#readme"
+}

--- a/sampler.js
+++ b/sampler.js
@@ -165,14 +165,14 @@
     var config = Reveal.getConfig() || {};
     config.sampler = config.sampler || {};
     var options = {
-        fetcherURL: config.sampler.fetcherURL || '',
+        proxyURL: config.sampler.proxyURL || '',
         removeIndentation: !!config.sampler.removeIndentation
     };
 
     var elements = document.querySelectorAll('[data-sample]');
     elements.forEach(function(element) {
         var slug = element.getAttribute('data-sample').match(/([^#]+)(?:#(.+))?/);
-        var file = options.fetcherURL + slug[1];
+        var file = options.proxyURL + slug[1];
         var selector = slug[2];
         var extractor = getSnippetExtractor(selector);
 

--- a/sampler.js
+++ b/sampler.js
@@ -159,21 +159,17 @@
     /**
      * Get an array of lines specified by start index and size
      *
-     * @param {number} start
-     * @param {number} length
+     * @param {number} [start=0]
+     * @param {number} [length]
      * @returns {SampleLine[]}
      */
     SampleFile.prototype.getLines = function(start, length) {
+        start = start > 0 ? start : 0;
+        if (typeof length === 'undefined') {
+            return this._lines.slice(start);
+        }
         return this._lines.slice(start, start + length);
     };
-
-    /**
-     * @returns {SampleLine[]}
-     */
-    SampleFile.prototype.getAll = function() {
-        return this.getLines(0, this._lines.length);
-    };
-
 
     /**
      * Fetches the files, creates and returns SampleFile objects. It keeps
@@ -286,7 +282,7 @@
                 }.bind(sample)(file)
             );
         } else {
-            sample.add(file.getAll() || []);
+            sample.add(file.getLines() || []);
         }
         return sample;
     };

--- a/sampler.js
+++ b/sampler.js
@@ -11,60 +11,291 @@
  */
 
 (function() {
-    // Escape a string so it can be used to match in a regular expression, even
-    // if it contains characters that are special for regular expressions.
-    var escapeForRegexp = function(s) {
-        return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+
+    /**
+     * @param {Number} lineNumber
+     * @param {string} text
+     * @constructor
+     *
+     * @property {Number} lineNumber
+     * @property {string} text
+     */
+    var SampleLine = function(lineNumber, text) {
+        this.lineNumber = lineNumber;
+        this.text = text || '';
     };
 
-    // Fetches a file at the given URL, and calls the `done` callback with the
-    // contents of the file as a string.
-    var fetch = function(url, done) {
-        var xhr = new XMLHttpRequest();
-        xhr.onreadystatechange = (function(xhr) {
-            return function() {
-                if (xhr.readyState === 4) {
-                    if ((xhr.status >= 200 && xhr.status < 300) ||
-                        (xhr.status === 0 && xhr.responseText !== '')) {
-                        done(xhr.responseText);
+    /**
+     * SampleFile provides access to the lines and named samples in a file
+     *
+     * @param {string} content
+     * @constructor
+     */
+    var SampleFile = function(content) {
+        var line, currentSnippets = [], token, i, c, k;
+        var parseLine = function(line) {
+            var match, token_definition;
+            for (var i = 0, c = SampleFile.TOKENS.length; i < c; i++) {
+                token_definition = SampleFile.TOKENS[i];
+                match = line.match(token_definition.pattern);
+                if (match) {
+                    return {
+                        type : token_definition.type,
+                        name : token_definition.nameIndex ? match[token_definition.nameIndex] : null
                     }
                 }
+            }
+            return false;
+        };
+        this._lines = content.split(/\r?\n/);
+        this._samples = {};
+        for (i = 0, c = this._lines.length; i < c; i++) {
+            line = this._lines[i];
+            token = parseLine(line);
+            if (token) {
+                switch (token.type) {
+                    case SampleFile.TOKEN_START_NAMED :
+                        currentSnippets.push(token.name);
+                        break;
+                    case SampleFile.TOKEN_END_NAMED :
+                        for (k = currentSnippets.length - 1; k >= 0; k--) {
+                            if (currentSnippets[k] === token.name) {
+                                currentSnippets.slice(k, 1);
+                            }
+                        }
+                        break;
+                    case SampleFile.TOKEN_END :
+                        if (currentSnippets.length > 0) {
+                            currentSnippets.pop();
+                        }
+                        break;
+                }
+            } else {
+                currentSnippets
+                    .filter(
+                        function(value, index, self) { return self.indexOf(value) === index; }
+                    )
+                    .forEach(
+                        function(index, line) {
+                            return function(name) {
+                                if (!this._samples.hasOwnProperty(name)) {
+                                    this._samples[name] = [];
+                                }
+                                this._samples[name].push(new SampleLine(index + 1, line));
+                            }.bind(this);
+                        }.bind(this)(i, line)
+                    )
+            }
+        }
+    };
+
+    SampleFile.TOKEN_START_NAMED = 'SAMPLE_START_NAMED';
+    SampleFile.TOKEN_END_NAMED = 'SAMPLE_END_NAMED';
+    SampleFile.TOKEN_END = 'SAMPLE_END';
+
+    // define patterns for snippet delimiters
+    SampleFile.TOKENS = [
+        {
+            type: SampleFile.TOKEN_START_NAMED,
+            // expects: sample(snippet-name)
+            pattern : /^[/*#\s]*sample\(([^)\r\n]+)\)/,
+            nameIndex : 1
+        },
+        {
+            type: SampleFile.TOKEN_END_NAMED,
+            // expects: end-sample(snippet-name)
+            pattern: /^[/*#\s]*end-sample\(([^)\r\n]+)\)/,
+            nameIndex: 1
+        },
+        {
+            type: SampleFile.TOKEN_END,
+            // expects: end-sample
+            pattern: /^[/*#\s]*end-sample/,
+            nameIndex: null
+        }
+    ];
+
+    /**
+     * Get an array of lines
+     *
+     * @param {string} name
+     * @returns {SampleLine[]}
+     */
+    SampleFile.prototype.getSample = function(name) {
+        return this._samples[name] || null;
+    };
+
+    /**
+     * Get an array of lines specified by start index and size
+     *
+     * @param {number} start
+     * @param {number} length
+     * @returns {SampleLine[]}
+     */
+    SampleFile.prototype.getLines = function(start, length) {
+        var lines = [];
+        var maximum = this._lines.length - 1;
+        var end;
+        if (maximum < 0) {
+            return null;
+        }
+        start = (start < 0) ? maximum + start : start;
+        end = (length < 0) ? maximum + length : start + length - 1;
+
+        for (var i = start; i <= end; i++) {
+            lines.push(new SampleLine(i + 1, this._lines[i]));
+        }
+        return lines;
+    };
+
+    /**
+     * @returns {SampleLine[]}
+     */
+    SampleFile.prototype.getAll = function() {
+        return this.getLines(0, this._lines.length);
+    };
+
+
+    /**
+     * Fetches the files, create and return SampleFile objects
+     *
+     * @constructor
+     */
+    var SampleFiles = function() {
+        this._files = {};
+        this._requests = {};
+    };
+
+    /**
+     * @callback SampleFilesFetchSuccess
+     * @param {SampleFile} file
+     */
+
+    /**
+     * Fetch file and execute callback with created SampleFile object
+     *
+     * @param {string} url
+     * @param {SampleFilesFetchSuccess} success
+     */
+    SampleFiles.prototype.fetch = function(url, success) {
+        var file, request;
+        file = this._files[url] || null;
+        if (file instanceof SampleFile) {
+            // found existing file object, execute callback
+            success(file);
+        }
+        request = this._requests[url] || null;
+        if (request instanceof Object) {
+            // found a request. store callback
+            request.success.push(success);
+        } else if (request === null) {
+            // create and store a new request
+            this._requests[url] = request = {
+                xhr : new XMLHttpRequest(),
+                success : [success]
             };
-        })(xhr);
-        xhr.open("GET", url);
-        try {
-            xhr.send();
-        }
-        catch (e) {
-            console.log('Failed to get the file ' + url);
+            request.xhr.onreadystatechange = function(url, request) {
+                return function() {
+                    if (request.xhr.readyState === XMLHttpRequest.DONE) {
+                        if (
+                            (request.xhr.status >= 200 && request.xhr.status < 300) ||
+                            (request.xhr.status === 0 && request.xhr.responseText !== '')
+                        ) {
+                            this._files[url] = file = new SampleFile(request.xhr.responseText);
+                            request.success.forEach(
+                              function(file) {
+                                  return function(success) {
+                                      success(file);
+                                  }
+                              }(file)
+                            );
+                            this._requests[url] = true;
+                        } else {
+                            console.log('Failed to get file: ' + url);
+                            this._requests[url] = false;
+                        }
+                    }
+                }.bind(this)
+            }.bind(this)(url, request);
+            request.xhr.open("GET", url);
+            try {
+                request.xhr.send();
+            }
+            catch (e) {
+                console.log('Error requesting file: ' + url);
+            }
         }
     };
 
-    // Given a string, returns a sub-string starting at the `index`th line,
-    // and stopping at the `index + length`th line.
-    var getLines = function(s, index, length) {
-        var match = s.match(
-            new RegExp('(?:.*\n){' + index + '}((?:.*(?:\n|$)){' + length + '})')
-        );
-        return match[1] || '';
+    /**
+     * @constructor
+     */
+    var Sample = function() {
+        this._lines = [];
     };
 
-    // Parses a string representing a single line number, a (start-end) range,
-    // or a comma-separated list thereof, and returns a list of ranges
-    // representing the union of those ranges. An individual line is
-    // considered a single-line range for that purpose.
-    var parseRanges = function(value) {
+    Sample.RANGE_NUMBERS = 'NUMBERS';
+    Sample.RANGE_NAMED = 'NAMED';
+
+    /**
+     * Create a Sample from a file using a selector
+     * @param {SampleFile} file
+     * @param {string} selector
+     */
+    Sample.createFromFile = function(file, selector) {
+        var sample = new Sample();
+        var ranges;
+        if (selector) {
+            ranges = Sample.parseSelector(selector);
+            ranges.forEach(
+                function(file) {
+                    return function(range) {
+                        var lines = null;
+                        switch (range.type) {
+                            case Sample.RANGE_NUMBERS :
+                                lines = file.getLines(range.start, range.length);
+                                break;
+                            case Sample.RANGE_NAMED :
+                                lines = file.getSample(range.name);
+                                break;
+                        }
+                        if (lines) {
+                            this.add(lines);
+                        }
+                    }.bind(this)
+                }.bind(sample)(file)
+            );
+        } else {
+            sample.add(file.getAll() || []);
+        }
+        return sample;
+    };
+
+    Sample.parseSelector = function(selector) {
+        var ranges = selector.split(",") || [];
+        var range, start, end;
         var result = [];
-        var ranges, range, start, end;
-        if (ranges = value.match(/(^|[,\s])\d+(-\d+)?/g)) {
-            for (var i = 0, c = ranges.length; i < c; i++) {
-                if (range = ranges[i].match(/(\d+)(?:-(\d+))?/)) {
-                    start = parseInt(range[1]) || 0;
-                    end = parseInt(range[2]) || start;
+        for (var i = 0, c = ranges.length; i < c; i++) {
+            // try to match a line number or range
+            range = ranges[i].match(/^\s*(\d+)(?:-(\d+))?\s*$/);
+            if (range) {
+                start = parseInt(range[1]) || 0;
+                end = parseInt(range[2]) || start;
+                result.push(
+                    {
+                        type: Sample.RANGE_NUMBERS,
+                        start: start - 1,
+                        length: end - start + 1
+                    }
+                )
+            } else {
+                // otherwise treat it as a name
+                range = ranges[i].trim();
+                if (range !== '') {
                     result.push(
                         {
-                            index: start - 1,
-                            length: end - start + 1
+                            type: Sample.RANGE_NAMED,
+                            name: range
                         }
                     )
                 }
@@ -73,14 +304,15 @@
         return result.length > 0 ? result : null;
     };
 
-    // Given ranges (as returned by `parseRanges`), returns a list of all the
-    // individual lines contained in that set of ranges.
-    var expandRangesToLinesIndex = function(ranges) {
+    Sample.parseSelectorToLineIndex = function(selector) {
         var lines = {};
+        var ranges = Sample.parseSelector(selector);
         if (ranges instanceof Array && ranges.length > 0) {
             for (var i = 0, c = ranges.length; i < c; i++) {
-                for (var x = 0; x < ranges[i].length; x++) {
-                    lines[ranges[i].index + x] = true;
+                if (ranges[i] instanceof Object && ranges[i].type === Sample.RANGE_NUMBERS) {
+                    for (var x = 0; x < ranges[i].length; x++) {
+                        lines[ranges[i].start + x] = true;
+                    }
                 }
             }
             return lines;
@@ -88,77 +320,83 @@
         return null;
     };
 
-    // Given the right side of a `#` in `path/to/file#selector`, returns a
-    // function that extracts the code snippet represented by `selector`
-    // from a string representing a source file.
-    var getSnippetExtractor = function(selector) {
-        var ranges = null, extractor = null;
-
-        // By default, match the whole file.
-        if (selector === undefined) {
-            extractor = function(code) { return code; }
-
-        // Selector for line numbers and ranges thereof.
-        } else if (ranges = parseRanges(selector)) {
-            extractor = function(code) {
-                return ranges.reduce(function(sample, range) {
-                    return sample + getLines(code, range.index, range.length);
-                }, '');
-            };
-
-        // Selector for named code samples.
-        } else {
-            extractor = function(code) {
-                var namedSampleRegexp = new RegExp(
-                    // match 'sample(sampleName)'
-                    /sample\(/.source + escapeForRegexp(selector) + /\)[^\n]*\n/.source +
-                    // match anything in between
-                    /^([\s\S]*?)/.source +
-                    // match 'end-sample'
-                    /^[^\n]*end-sample/.source, 'mg');
-                var sample = '', match = null;
-                while ((match = namedSampleRegexp.exec(code)) !== null) {
-                    sample += match[1];
+    /**
+     * @param {SampleLine[]} lines
+     */
+    Sample.prototype.add = function(lines) {
+        this._lines.push.apply(
+            this._lines,
+            lines.filter(
+                /**
+                 * Skip lines that contain the `skip-sample` tag.
+                 *
+                 * @param {SampleLine} line
+                 * @returns {boolean}
+                 */
+                function(line) {
+                    return (
+                        line instanceof SampleLine &&
+                        line.text.indexOf('skip-sample') === -1
+                    );
                 }
-                return sample;
-            };
-        }
-
-        var postProcess = function(code) {
-            // Strip trailing newline in the sample (if any), since that is
-            // only required to insert the 'end-sample' tag.
-            code = code.replace(/\n$/, "");
-
-            // Skip lines that contain the `skip-sample` tag.
-            var lines = code.split("\n");
-            lines = lines.filter(function(line) {
-                return line.indexOf('skip-sample') == -1;
-            });
-
-            return lines.join('\n');
-        };
-
-        return function(code) { return postProcess(extractor(code)); };
+            )
+        );
     };
 
-    // To remove the indentation find the shortest leading whitespace sequence
-    // and remove it from all lines.
-    var removeIndentationFromLines = function(code) {
-        var indent, indentPattern;
-        var indentMatch = code.match(/^[ \t]+/mg);
-        if (indentMatch) {
-            indent = indentMatch.reduce(
-                function(previousValue, currentValue) {
-                    if (previousValue.length < currentValue.length) {
-                        return previousValue;
-                    }
-                    return currentValue;
-                }
-            );
-            indentPattern = new RegExp('^' + indent + '', 'mg');
-            return code.replace(indentPattern, '');
+    /**
+     * @param {HTMLElement} parentNode
+     * @param {{removeIndentation: boolean, marked: string, lineNumbers}} options
+     */
+    Sample.prototype.appendTo = function(parentNode, options) {
+        var line, lineNode, previousLineNode = null;
+        var document = parentNode.ownerDocument;
+        var indentationOffset = (options.removeIndentation) ? this.getIndentationLength() : 0;
+        var marked = Sample.parseSelectorToLineIndex(options.marked || '') || {};
+        var lineNumberStart =  parseInt(options.lineNumbers) || 0;
+        if (options.lineNumbers === true || options.lineNumbers === 'true' || options.lineNumbers === 'yes') {
+            lineNumberStart = 1;
         }
-        return code;
+        parentNode.setAttribute('data-noescape', '');
+        for (var i = 0, c = this._lines.length; i < c; i++) {
+            line = this._lines[i];
+            lineNode = parentNode.appendChild(document.createElement('span'));
+            lineNode.setAttribute('class', 'line');
+            if (options.lineNumbers === 'original') {
+                lineNode.setAttribute('data-line-number', line.lineNumber);
+            } else if (lineNumberStart > 0) {
+                lineNode.setAttribute('data-line-number', lineNumberStart + i);
+            }
+            if (marked[i]) {
+                lineNode
+                    .appendChild(document.createElement('mark'))
+                    .appendChild(document.createTextNode(line.text.substr(indentationOffset)));
+            } else {
+                lineNode.appendChild(document.createTextNode(line.text.substr(indentationOffset)));
+            }
+            if (previousLineNode) {
+                previousLineNode.appendChild(document.createTextNode('\n'));
+            }
+            previousLineNode = lineNode;
+        }
+    };
+
+    Sample.prototype.getIndentationLength = function() {
+        return Math.min.apply(
+            null,
+            this
+                ._lines
+                .filter(
+                    function (line) {
+                        return line.text.trim() !== '';
+                    }
+                )
+                .map(
+                function (line) {
+                    var indentation = line.text.match(/^[ \t]+/);
+                    return indentation ? indentation[0].length : 0
+                }
+            )
+        ) || 0;
     };
 
     // Read configuration options
@@ -166,71 +404,59 @@
     config.sampler = config.sampler || {};
     var options = {
         proxyURL: config.sampler.proxyURL || '',
-        removeIndentation: !!config.sampler.removeIndentation
+        removeIndentation: !!config.sampler.removeIndentation,
+        lineNumbers: [true, 'original'].indexOf(config.sampler.lineNumbers) !== -1
+            ? config.sampler.lineNumbers : false
     };
 
+    var files = new SampleFiles();
     var elements = document.querySelectorAll('[data-sample]');
-    elements.forEach(function(element) {
-        var slug = element.getAttribute('data-sample').match(/([^#]+)(?:#(.+))?/);
-        var file = options.proxyURL + slug[1];
-        var selector = slug[2];
-        var extractor = getSnippetExtractor(selector);
+    elements.forEach(
+        /**
+         *
+         * @param {HTMLElement} element
+         */
+        function(element) {
+            var slug = element.getAttribute('data-sample').match(/([^#]+)(?:#(.+))?/);
+            var url = options.proxyURL + slug[1];
+            var selector = slug[2] || '';
 
-        fetch(file, function(code) {
-            // Extract the sample from the source file
-            var sample = extractor(code);
-            if (sample === '') {
-                throw "Could not find sample '" + selector + "' in file '" + file + "'.";
-            }
+            files.fetch(
+                url,
+                function (sampleFile) {
+                    var sample = Sample.createFromFile(sampleFile, selector);
+                    var attributes = {
+                        mark : element.getAttribute('data-sample-mark') || '',
+                        indent: element.getAttribute('data-sample-indent'),
+                        lineNumbers: element.getAttribute('data-sample-line-numbers')
+                    };
 
-            // Read indentation behaviour defined by attribute or global option
-            var removeIndentation;
-            switch (element.getAttribute('data-sample-indent')) {
-                case 'keep' :
-                    removeIndentation = false;
-                    break;
-                case 'remove':
-                    removeIndentation = true;
-                    break;
-                default :
-                    removeIndentation = options.removeIndentation;
-            }
-            if (removeIndentation) {
-              sample = removeIndentationFromLines(sample);
-            }
+                    sample.appendTo(
+                        element,
+                        {
+                            // marked lines selector
+                            marked: attributes.mark,
+                            // indentation behaviour defined by attribute or global option
+                            removeIndentation:
+                                attributes.indent === 'remove' ||
+                                (options.removeIndentation && attributes.indent !== 'keep'),
+                            // line numbers behaviour
+                            lineNumbers: attributes.lineNumbers || options.lineNumbers
+                        }
+                    );
 
-            // Mark lines in the sample, if requested.
-            var marked = expandRangesToLinesIndex(
-                parseRanges(element.getAttribute('data-sample-mark') || '')
-            );
-            if (marked) {
-                element.textContent = '';
-                element.setAttribute('data-noescape', '');
-                var lines = sample.split("\n");
-                for (var j = 0; j < lines.length; j++) {
-                    if (j > 0) {
-                        element.appendChild(document.createTextNode("\n"));
+                    // Add the right `language-xyz` class to the code block, if required.
+                    var extension = url.split('.').pop();
+                    var classString = element.getAttribute('class') || '';
+                    if (!classString.match(/(^|\s)lang(uage)?-/)) {
+                        element.setAttribute('class', classString + ' language-' + extension);
                     }
-                    if (marked[j]) {
-                        element.appendChild(document.createElement('mark'))
-                               .appendChild(document.createTextNode(lines[j]))
-                    } else {
-                        element.appendChild(document.createTextNode(lines[j]));
+                    if (typeof hljs !== 'undefined') {
+                        hljs.highlightBlock(element);
                     }
                 }
-            } else {
-                element.textContent = sample;
-            }
+            );
+        }
+    );
 
-            // Add the right `language-xyz` class to the code block, if required.
-            var extension = file.split('.').pop();
-            var classString = element.getAttribute('class') || '';
-            if (!classString.match(/(^|\s)lang(uage)?-/)) {
-                element.setAttribute('class', classString + ' language-' + extension);
-            }
-            if (typeof hljs !== 'undefined') {
-                hljs.highlightBlock(element);
-            }
-        });
-    });
 })();

--- a/sampler.js
+++ b/sampler.js
@@ -232,7 +232,6 @@
                     )
             }
         }
-        console.log(this._samples, this._lines);
     };
 
     /**

--- a/sampler.js
+++ b/sampler.js
@@ -153,7 +153,7 @@
     /**
      * @param {Number} lineNumber
      * @param {string} text
-     * @param {Number} type
+     * @param {Sampler.TokenMatcher.TOKEN} type
      * @constructor
      * @memberof Sampler
      *
@@ -423,6 +423,7 @@
 
     /**
      * Expands line numbers and ranges to an object with the line index as key.
+     *
      *     3-6,12 => {2: true, 3: true, 4: true, 5: true, 11: true}
      *
      * @param {string} selector

--- a/sampler.js
+++ b/sampler.js
@@ -165,13 +165,14 @@
     var config = Reveal.getConfig() || {};
     config.sampler = config.sampler || {};
     var options = {
+        fetcherURL: config.sampler.fetcherURL || '',
         removeIndentation: !!config.sampler.removeIndentation
     };
 
     var elements = document.querySelectorAll('[data-sample]');
     elements.forEach(function(element) {
         var slug = element.getAttribute('data-sample').match(/([^#]+)(?:#(.+))?/);
-        var file = slug[1];
+        var file = options.fetcherURL + slug[1];
         var selector = slug[2];
         var extractor = getSnippetExtractor(selector);
 

--- a/sampler.js
+++ b/sampler.js
@@ -1,7 +1,6 @@
 /**
  * sampler.js is a plugin to display code samples from specially-formatted
  * source files in reveal.js slides.
- *package
  *
  * @namespace Sampler
  * @author Louis Dionne

--- a/sampler.js
+++ b/sampler.js
@@ -199,6 +199,9 @@
         for (i = 0, c = lines.length; i < c; i++) {
             lineType = TokenMatcher.TOKEN.LINE;
             lineText = lines[i];
+            if (i === c - 1 && lineText === '') {
+                break;
+            }
             token = matcher.identify(lineText, language);
             if (token) {
                 lineType = token.type;

--- a/sampler.js
+++ b/sampler.js
@@ -17,7 +17,7 @@
      * @param {string} value
      * @param {number} targetLength
      * @param {string} [padString= ]
-     * @returns {*}
+     * @returns {string}
      */
     var stringPadStart = function(value, targetLength, padString) {
         padString = String(typeof padString !== 'undefined' ? padString : ' ');
@@ -329,6 +329,14 @@
         return result.length > 0 ? result : null;
     };
 
+    /**
+     * Expands line numbers and ranges to an object with the line index as key.
+     *
+     *     3-6,12 => {2: true, 3: true, 4: true, 5: true, 11: true}
+     *
+     * @param selector
+     * @returns {(null|{})}
+     */
     Sample.parseSelectorToLineIndex = function(selector) {
         var lines = {};
         var ranges = Sample.parseSelector(selector);
@@ -369,7 +377,7 @@
     };
 
     /**
-     * @param {bool} skipDelimiters
+     * @param {boolean} skipDelimiters
      * @param {number[]} skipLines - skip lines by index
      * @returns {SampleLine[]}
      */
@@ -402,10 +410,10 @@
         var line, lineNode, previousLineNode, lineText = null;
         var markedLinePattern = /(\s*(\/\/|#)\s*mark-sample\s*$)|(\s*\/\*\s*mark-sample\s*\*\/(\s*$)?)|(\s*<!--\s*mark-sample\s*-->(\s*$)?)/;
         var document = parentNode.ownerDocument;
-        var indentationOffset = (options.removeIndentation) ? this.getIndentationLength() : 0;
         var marked = Sample.parseSelectorToLineIndex(options.marked || '') || {};
         var lineNumberStart =  parseInt(options.lineNumbers) || 0, lineNumberSize;
         var lines = this.getLines(options.skip.delimiters, options.skip.lines);
+        var indentationOffset = (options.removeIndentation) ? this.getIndentationLength(lines) : 0;
         if (lines.length < 1) {
             return;
         }
@@ -446,11 +454,17 @@
         }
     };
 
-    Sample.prototype.getIndentationLength = function() {
+    /**
+     * Get the length of the shortest whitespace sequence at a line start
+     *
+     * @param {SampleLine[]} [lines]
+     * @returns {number}
+     */
+    Sample.prototype.getIndentationLength = function(lines) {
+        lines = lines instanceof Array ? lines : this._lines;
         return Math.min.apply(
             null,
-            this
-                ._lines
+            lines
                 .filter(
                     function (line) {
                         return line.text.trim() !== '';

--- a/sampler.js
+++ b/sampler.js
@@ -60,7 +60,7 @@
                     case SampleFile.TOKEN_END_NAMED :
                         for (k = currentSnippets.length - 1; k >= 0; k--) {
                             if (currentSnippets[k] === token.name) {
-                                currentSnippets.slice(k, 1);
+                                currentSnippets.splice(k, 1);
                             }
                         }
                         break;
@@ -157,7 +157,8 @@
 
 
     /**
-     * Fetches the files, create and return SampleFile objects
+     * Fetches the files, creates and returns SampleFile objects. It keeps
+     * track of requests so that each file is requested once only.
      *
      * @constructor
      */


### PR DESCRIPTION
After reading the open issues I started to refactor the source for them and it got a little out of hand. :-P

It is a complete refactoring, changing the approach to a small line parser for the files. `Sampler.Files` keeps track of the requested files and creates `Sampler.File` objects with named samples and lines. The `Sampler.Line` objects store the line content, number and type. It allows the files to be fetched and parsed once only. `Sampler.Sample` appends the selected snippets/lines.

* Implement #8: mark lines using comments in the source file
* Implement #9: skip sample delimiter lines
* Implement #10: allow overlapping sample sections
* Implement: output line numbers
* Implement: skip lines by number
* Implement: allow to mix names and line ranges in sample selector
* Implement: configure language specific patterns 