### PR TITLE
Don't ignore non-trivial lines with no indentation

### DIFF
--- a/sampler.js
+++ b/sampler.js
@@ -145,7 +145,7 @@
     // and remove it from all lines.
     var removeIndentationFromLines = function(code) {
         var indent, indentPattern;
-        var indentMatch = code.match(/^[ \t]+/mg);
+        var indentMatch = code.match(/^[ \t]*(?=\S)/mg);
         if (indentMatch) {
             indent = indentMatch.reduce(
                 function(previousValue, currentValue) {


### PR DESCRIPTION
When using the removeIndentation setting globally and including whole
files, I notice that an odd thing happens. All code that is indented is
outdented by one level! On investigation, this is caused by ignoring
lines that begin without whitespace when computing the indentation level
to consider the base.

With this modified regex you still get the same result, ie a string of
leading whitespace, however a line without leading whitespace still
matches and the length of that result is 0. The trivial case of an
entirely blank line is also handled by including a zero-width forward
lookahead assertion that some non-whitespace character must occur after
the leading optional indentation in order for that line to be included
in the match.